### PR TITLE
[Feature] Add theme commands ``list`` and ``compile``

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ The contao theme compiler bundle adds the functionality to compile selected scss
 + [Features](#features)
 + [How to install](#how-to-install-the-package)
 + [Initial setup](#initial-setup)
++ [Console commands](#console-commands)
 
 ## Features
 
@@ -42,7 +43,28 @@ Search for contao theme compiler bundle and add it to your extensions.
    ![Admin View: Advanced form overview](https://www.oveleon.de/share/github-assets/contao-theme-compiler-bundle/themeSettings.jpg)
 
 
-5. Compile in your theme-settings, within your theme overview or under maintenance
+5. Compile in your theme-settings, within your theme overview, under maintenance or via console command
 
    ![Admin View: Advanced form overview](https://www.oveleon.de/share/github-assets/contao-theme-compiler-bundle/themeOverview.jpg)
    ![Admin View: Advanced form overview](https://www.oveleon.de/share/github-assets/contao-theme-compiler-bundle/maintenanceSettings.jpg)
+
+   ```
+   php vendor/bin/contao-console contao:themecompiler:compile [id]
+   ```
+   
+## Console commands
+
+### List themes
+
+- Output a list your of your themes within ``tl_theme``
+
+```
+php vendor/bin/contao-console contao:themecompiler:list
+```
+
+### Compile theme
+
+- Compile a theme with following command ([id] is mandatory):
+```
+php vendor/bin/contao-console contao:themecompiler:compile [id]
+```

--- a/config/commands.yml
+++ b/config/commands.yml
@@ -1,0 +1,14 @@
+services:
+  _defaults:
+    autoconfigure: true
+    public: false
+
+  contao.themecompiler.list:
+    class: Oveleon\ContaoThemeCompilerBundle\Command\ThemeListCommand
+    arguments:
+      - '@contao.framework'
+
+  contao.themecompiler.compile:
+    class: Oveleon\ContaoThemeCompilerBundle\Command\ThemeCompileCommand
+    arguments:
+      - '@contao.framework'

--- a/src/Command/ThemeCompileCommand.php
+++ b/src/Command/ThemeCompileCommand.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao Theme Compiler Bundle.
+ *
+ * @package     contao-theme-compiler-bundle
+ * @license     MIT
+ * @author      Daniele Sciannimanica  <https://github.com/doishub>
+ * @copyright   Oveleon                <https://www.oveleon.de/>
+ */
+
+namespace Oveleon\ContaoThemeCompilerBundle\Command;
+
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Oveleon\ContaoThemeCompilerBundle\FileCompiler;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Converts the StyleManager object to the new schema.
+ *
+ * @internal
+ */
+class ThemeCompileCommand extends Command
+{
+    protected static $defaultName = 'contao:themecompiler:compile';
+    protected static $defaultDescription = 'Compiles themes that are registered with contao-theme-compiler-bundle.';
+
+    protected ContaoFramework $framework;
+
+    public function __construct(ContaoFramework $contaoFramework)
+    {
+        $this->framework = $contaoFramework;
+        $this->framework->initialize();
+
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('id', InputArgument::REQUIRED, 'The id of the theme.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if (null === $input->getArgument('id'))
+        {
+            return Command::FAILURE;
+        }
+
+        $io = new SymfonyStyle($input, $output);
+        $this->framework->initialize();
+
+        try
+        {
+            $compiler = (new FileCompiler($input->getArgument('id')));
+            $compiler->compileAll();
+
+            $arrMessages = $compiler->getMessages();
+
+            if (empty($arrMessages))
+            {
+                $io->error('No configurations could be found');
+            }
+            else
+            {
+                foreach ($arrMessages as $arrMessage) {
+
+                    $type    = $arrMessage['type'];
+                    $message =  $arrMessage['message'];
+
+                    switch ($type)
+                    {
+                        case FileCompiler::MSG_HEAD:
+                            $io->title($message);
+                            break;
+
+                        case FileCompiler::MSG_ERROR:
+                        case FileCompiler::MSG_WARN:
+                            $io->warning($message);
+                            break;
+
+                        case FileCompiler::MSG_SUCCESS:
+                            $io->success($message);
+                            break;
+
+                        default:
+                            $io->block($message, 'INFO', 'fg=yellow', ' ');
+                    }
+                }
+            }
+        }
+        catch(\Exception $e)
+        {
+            $io->error($e->getMessage());
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Command/ThemeListCommand.php
+++ b/src/Command/ThemeListCommand.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao Theme Compiler Bundle.
+ *
+ * @package     contao-theme-compiler-bundle
+ * @license     MIT
+ * @author      Daniele Sciannimanica  <https://github.com/doishub>
+ * @copyright   Oveleon                <https://www.oveleon.de/>
+ */
+
+namespace Oveleon\ContaoThemeCompilerBundle\Command;
+
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\FilesModel;
+use Contao\ThemeModel;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Converts the StyleManager object to the new schema.
+ *
+ * @internal
+ */
+class ThemeListCommand extends Command
+{
+    protected static $defaultName = 'contao:themecompiler:list';
+    protected static $defaultDescription = 'Gets a list of all themes';
+
+    protected ContaoFramework $framework;
+
+    public function __construct(ContaoFramework $contaoFramework)
+    {
+        $this->framework = $contaoFramework;
+        $this->framework->initialize();
+
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $this->framework->initialize();
+
+        $objTheme = ThemeModel::findAll();
+
+        $io->title('Themes');
+
+        if ($objTheme !== null)
+        {
+            while ($objTheme->next())
+            {
+                $outputDir = (FilesModel::findByUuid($objTheme->outputFilesTargetDir))->path ?? '{{empty}}';
+
+                $io->block(
+                    $objTheme->name . ' [Target directory: ' . $outputDir . ' ]',
+                    (string) $objTheme->id,
+                    'fg=yellow',
+                    ' '
+                );
+            }
+        }
+        else
+        {
+            $io->warning('No themes have been found');
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/DependencyInjection/ContaoThemeCompilerExtension.php
+++ b/src/DependencyInjection/ContaoThemeCompilerExtension.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of Contao Theme Compiler Bundle.
+ *
+ * @package     contao-theme-compiler-bundle
+ * @license     MIT
+ * @author      Daniele Sciannimanica  <https://github.com/doishub>
+ * @copyright   Oveleon                <https://www.oveleon.de/>
+ */
+
+namespace Oveleon\ContaoThemeCompilerBundle\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+
+class ContaoThemeCompilerExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        $loader = new YamlFileLoader(
+            $container,
+            new FileLocator(__DIR__.'/../../config')
+        );
+
+        $loader->load('commands.yml');
+    }
+}


### PR DESCRIPTION
<h3>Feature</h3>

- Added ``contao:themecompiler:list`` - list all themes and their outputDir https://github.com/oveleon/contao-theme-compiler-bundle/commit/532abc3140690f30ca05babbadb733201968d089

- Added ``contao:themecompiler:compile [id]`` - compile a theme by ID https://github.com/oveleon/contao-theme-compiler-bundle/commit/532abc3140690f30ca05babbadb733201968d089

Closes https://github.com/contao-thememanager/core/issues/11