### PR TITLE
Feature: Enable passing customSkinFiles to FileCompiler

### DIFF
--- a/src/Compiler/FileCompiler.php
+++ b/src/Compiler/FileCompiler.php
@@ -84,6 +84,11 @@ class FileCompiler
     protected string $rootDir;
 
     /**
+     * Custom skin files
+     */
+    public array $customSkinFiles = [];
+
+    /**
      * FileCompiler constructor.
      */
     public function __construct($themeId)
@@ -181,9 +186,9 @@ class FileCompiler
     public function compileSkinFiles(): void
     {
         $arrContent = [];
-        $skinFiles  = StringUtil::deserialize($this->objTheme->skinSourceFiles);
+        $skinFiles = array_merge($this->customSkinFiles, StringUtil::deserialize($this->objTheme->skinSourceFiles, true));
 
-        if (null !== $skinFiles)
+        if (!empty($skinFiles))
         {
             // reverse loading order so following skin files will override configurations from previous ones
             $skinFiles = array_reverse($skinFiles);

--- a/src/Compiler/FileCompiler.php
+++ b/src/Compiler/FileCompiler.php
@@ -204,7 +204,7 @@ class FileCompiler
                     continue;
                 }
 
-                $this->msg('Compile file: ' . $file->path . '/' . $file->name);
+                $this->msg('Compile file: ' . $file->path);
 
                 $filename = StringUtil::standardize(basename($file->name, $file->extension));
                 $content  = $this->getFileContent($file->path);


### PR DESCRIPTION
This PR introduces a feature to pass custom skin files to the FileCompiler.

<h3>Additions</h3>
- Added a new array property $customSkinFiles to the FileCompiler https://github.com/oveleon/contao-theme-compiler-bundle/commit/258dabdf83028507a0b97e4149427deec018713a

  > **e. g. via beforeCompile Hook ($GLOBALS['TC_HOOKS']['beforeCompile'])**
  > ```php
  > $compiler->customSkinFiles[] = 'YOUR-FILE-UUID'
  > ```
  
<h3>Bugfix</h3>

- Correctly display output log for skin files https://github.com/oveleon/contao-theme-compiler-bundle/commit/33e545374ddd94ed68f0c82fc9d2509d43148d41