### PR TITLE
Enhancing contao-config-driver-bundle

### DIFF
--- a/contao/dca/tl_theme.php
+++ b/contao/dca/tl_theme.php
@@ -36,9 +36,10 @@ $GLOBALS['TL_DCA']['tl_theme']['fields']['skinSourceFiles'] = [
 
 $GLOBALS['TL_DCA']['tl_theme']['fields']['combineSkinFiles'] = [
     'label'           => &$GLOBALS['TL_LANG']['tl_theme']['combineSkinFiles'],
+    'default'         => true,
     'exclude'         => true,
     'inputType'       => 'checkbox',
-    'sql'             => "char(1) NOT NULL default ''"
+    'sql'             => "char(1) NOT NULL default '1'"
 ];
 
 $GLOBALS['TL_DCA']['tl_theme']['fields']['outputFilesTargetDir'] = [
@@ -60,4 +61,5 @@ $GLOBALS['TL_DCA']['tl_theme']['fields']['backupFiles'] = [
 PaletteManipulator::create()
     ->addLegend('compiler_legend', 'vars_legend', PaletteManipulator::POSITION_BEFORE)
     ->addField(['skinSourceFiles', 'outputFilesTargetDir', 'combineSkinFiles', 'backupFiles'], 'compiler_legend', PaletteManipulator::POSITION_APPEND)
-    ->applyToPalette('default', 'tl_theme');
+    ->applyToPalette('default', 'tl_theme')
+;

--- a/src/Compiler/FileCompiler.php
+++ b/src/Compiler/FileCompiler.php
@@ -417,42 +417,42 @@ class FileCompiler
     /**
      * Parse config fields by configField
      */
-    public function parseConfig($sourceField): void
+    public function parseConfig($configType): void
     {
-        if ($sourceField)
+        if ($configType)
         {
-            $configVars = $this->objTheme->{$sourceField};
-
-            if ($configVars)
+            if (!$configVars = $this->objTheme->{$configType})
             {
-                $configVars = StringUtil::deserialize($configVars, true);
-
-                if (isset($GLOBALS['TC_HOOKS']['compilerParseConfig']) && \is_array($GLOBALS['TC_HOOKS']['compilerParseConfig']))
-                {
-                    foreach ($GLOBALS['TC_HOOKS']['compilerParseConfig'] as $callback)
-                    {
-                        System::importStatic($callback[0])->{$callback[1]}($this, $configVars);
-                    }
-                }
-
-                $strConfig  = '';
-
-                foreach ($configVars as $key => $varValue)
-                {
-                    $configVal = $this->parseVariableValue($varValue);
-
-                    if ($configVal || is_bool($configVal))
-                    {
-                        $strConfig .= sprintf("$%s:%s;\n", $key, is_bool($configVal) ? ($configVal ? 'true' : 'false')  : $configVal);
-                    }
-                }
-
-                $this->config = $strConfig;
-
-                $this->msg('Config Variables', self::MSG_HEAD);
-                $this->msg('Theme: ' . $this->objTheme->name);
-                $this->msg('Column: ' . $sourceField);
+                $configVars = [];
             }
+
+            $configVars = StringUtil::deserialize($configVars, true);
+
+            if (isset($GLOBALS['TC_HOOKS']['compilerParseConfig']) && \is_array($GLOBALS['TC_HOOKS']['compilerParseConfig']))
+            {
+                foreach ($GLOBALS['TC_HOOKS']['compilerParseConfig'] as $callback)
+                {
+                    System::importStatic($callback[0])->{$callback[1]}($this, $configVars);
+                }
+            }
+
+            $strConfig  = '';
+
+            foreach ($configVars as $key => $varValue)
+            {
+                $configVal = $this->parseVariableValue($varValue);
+
+                if ($configVal || is_bool($configVal))
+                {
+                    $strConfig .= sprintf("$%s:%s;\n", $key, is_bool($configVal) ? ($configVal ? 'true' : 'false')  : $configVal);
+                }
+            }
+
+            $this->config = $strConfig;
+
+            $this->msg('Config Variables', self::MSG_HEAD);
+            $this->msg('Theme: ' . $this->objTheme->name);
+            $this->msg('Column: ' . $configType);
         }
     }
 

--- a/src/Utils/CompilerUtils.php
+++ b/src/Utils/CompilerUtils.php
@@ -31,7 +31,7 @@ class CompilerUtils extends Backend
 	 */
 	public function addSaveNCompileButton(array $arrButtons, DataContainer $dc): array
 	{
-		$blnDisabled = $dc->activeRecord && !$dc->activeRecord->tstamp;
+		$blnDisabled = !$dc->activeRecord;
 
 		$arrButtons['saveNcompile'] = '<button type="submit" name="saveNcompile" id="saveNcompile" class="tl_submit themeCompileButton" accesskey="t" ' . ($blnDisabled ? "disabled" : "") . '>' . Image::getHtml('bundles/contaothemecompiler/icons/compile.svg') . ($GLOBALS['TL_LANG']['MSC']['saveNcompile'] ?? null) . '</button> ';
 


### PR DESCRIPTION
<h3>Changes</h3>

- Theme files are now combined by default https://github.com/oveleon/contao-theme-compiler-bundle/commit/88af20da644d5988c2d7317dda7e512a7823c69d

<h3>Features</h3>

- Consider default configuration files from oveleon/contao-config-driver-bundle https://github.com/oveleon/contao-theme-compiler-bundle/commit/489d6aef59a7779ff5f4c809afb89b34c8087e40

- Allow saving & compiling when on newly created themes when using bundle configuration with oveleon/contao-config-driver-bundle https://github.com/oveleon/contao-theme-compiler-bundle/commit/29af8d35966ae56a6d609f6d9aac5902b78e3a0e
